### PR TITLE
Add PHP example for Merchant API authentication hash calculation

### DIFF
--- a/PHP/CalculateMerchantApiHash.php
+++ b/PHP/CalculateMerchantApiHash.php
@@ -35,8 +35,7 @@ $requestContent = json_encode($content);
 {"rows":[{"amount":1000,"description":"Test Product","vatPercent":2400}],"email":"customer@email.com","notifyUrl":"https:\/\/url.to.shop\/apiNotification\/"}
 */
 
-$method = 'POST'; // For creating refund, method is POST
-$timestamp = '2020-05-01T12:00:00+0300'; // 2020-05-01T12:00:00+0300
+$timestamp = (new DateTime())->format(DateTimeInterface::RFC3339); // 2020-05-01T12:00:00+0300
 
 $md5Hash = hash('md5', $requestContent, true); // MD5 hash is in binary
 $contentMd5 = base64_encode($md5Hash); // nYDNvmvsxI4ZxJL8OghRTw==

--- a/PHP/CalculateMerchantApiHash.php
+++ b/PHP/CalculateMerchantApiHash.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This is example for calculating Merchant API authentication hash in case of refund.
+ * Merchant API GET requests have always empty content, in this case use empty string as $requestContent variable when calculating content MD5
+ */
+
+$paymentId = 102402728626; // Payment id is returned after returning from payment back, $_GET['PAYMENT_ID'];
+
+// Test merchant credentials
+$merchantId = 13466;
+$merchantSecret = '6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ';
+
+$url = 'https://api.paytrail.com/merchant/v1/payments/' . $paymentId . '/refunds';
+$method = 'POST'; // Creating refund uses POST method
+
+// Product we want to refund
+$product = [
+   'amount' => 1000, // Price is in cents, in this case price is 10.00€
+   'description' => 'Test Product',
+   'vatPercent' => 2400, // Vat 24.00%, comma is removed
+];
+
+// Create message content
+$content = [
+   'rows' => [
+      $product,
+   ],
+   'email' => 'customer@email.com', // Customer email address
+   'notifyUrl' => 'https://url.to.shop/apiNotification/', // Paytrail API will send return message to this url
+];
+
+$requestContent = json_encode($content);
+/* Output is following
+{"rows":[{"amount":1000,"description":"Test Product","vatPercent":2400}],"email":"customer@email.com","notifyUrl":"https:\/\/url.to.shop\/apiNotification\/"}
+*/
+
+$method = 'POST'; // For creating refund, method is POST
+$timestamp = '2020-05-01T12:00:00+0300'; // 2020-05-01T12:00:00+0300
+
+$md5Hash = hash('md5', $requestContent, true); // MD5 hash is in binary
+$contentMd5 = base64_encode($md5Hash); // nYDNvmvsxI4ZxJL8OghRTw==
+
+$hashHmacContent = implode("\n", [
+   $method,
+   $url,
+   'PaytrailMerchantAPI ' . $merchantId,
+   $timestamp,
+   $contentMd5,
+]);
+/* This will output following string with line break character \n
+POST
+https://api.paytrail.com/merchant/v1/payments/102402728626/refunds
+PaytrailMerchantAPI 13466
+2020-05-01T12:00:00+0300
+nYDNvmvsxI4ZxJL8OghRTw==
+*/
+
+$hashHmac = hash_hmac('sha256', $hashHmacContent, $merchantSecret, true); // Merchant secret is used as key, result is in binary
+
+$authenticationHash = base64_encode($hashHmac); // YqpU4WCsnBn7XLOqNd29bu/qfybVP4kIsbeOKOrSifU
+
+// Message headers
+$requestHeaders = [
+   'Timestamp' => $timestamp, // This needs to be same timestamp used in calculating $authenticationHash
+   'Content-MD5' => $contentMd5,
+   'Authorization' => 'PaytrailMerchantAPI ' . $merchantId . ':' . $authenticationHash,
+   'Refund-Origin' => 'internal', // This is required when using payment id as identifier
+];
+
+// Request body is $requestContent variable set earlier.

--- a/PHP/CalculateMerchantApiHash.php
+++ b/PHP/CalculateMerchantApiHash.php
@@ -57,7 +57,7 @@ nYDNvmvsxI4ZxJL8OghRTw==
 
 $hashHmac = hash_hmac('sha256', $hashHmacContent, $merchantSecret, true); // Merchant secret is used as key, result is in binary
 
-$authenticationHash = base64_encode($hashHmac); // YqpU4WCsnBn7XLOqNd29bu/qfybVP4kIsbeOKOrSifU
+$authenticationHash = base64_encode($hashHmac); // YqpU4WCsnBn7XLOqNd29bu/qfybVP4kIsbeOKOrSifU=
 
 // Message headers
 $requestHeaders = [


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PHP example to calculate Merchant API authentication code, this example uses refund creation as example.

## Tests

- [X] Not needed
- [ ] Unit tests added
- [ ] Integration tests added

## Related Tickets & Documents

Code example to https://github.com/paytrail/documentation/issues/6

## Code of Conduct

- [X] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
