### PR TITLE
Use correct url parameter for merchant hash generation

### DIFF
--- a/PHP/CalculateMerchantApiHash.php
+++ b/PHP/CalculateMerchantApiHash.php
@@ -11,7 +11,7 @@ $paymentId = 102402728626; // Payment id is returned after returning from paymen
 $merchantId = 13466;
 $merchantSecret = '6pKF4jkv97zmqBJ3ZL8gUw5DfT2NMQ';
 
-$url = 'https://api.paytrail.com/merchant/v1/payments/' . $paymentId . '/refunds';
+$url = '/payments/' . $paymentId . '/refunds';
 $method = 'POST'; // Creating refund uses POST method
 
 // Product we want to refund
@@ -49,7 +49,7 @@ $hashHmacContent = implode("\n", [
 ]);
 /* This will output following string with line break character \n
 POST
-https://api.paytrail.com/merchant/v1/payments/102402728626/refunds
+/payments/102402728626/refunds
 PaytrailMerchantAPI 13466
 2020-05-01T12:00:00+0300
 nYDNvmvsxI4ZxJL8OghRTw==
@@ -57,7 +57,7 @@ nYDNvmvsxI4ZxJL8OghRTw==
 
 $hashHmac = hash_hmac('sha256', $hashHmacContent, $merchantSecret, true); // Merchant secret is used as key, result is in binary
 
-$authenticationHash = base64_encode($hashHmac); // YqpU4WCsnBn7XLOqNd29bu/qfybVP4kIsbeOKOrSifU=
+$authenticationHash = base64_encode($hashHmac); // FC3VbM1exdamMZ03z8gKt4WA/R0BFsDPo6YSh64vBbU=
 
 // Message headers
 $requestHeaders = [
@@ -68,3 +68,4 @@ $requestHeaders = [
 ];
 
 // Request body is $requestContent variable set earlier.
+// Request is sent to 'https://api.paytrail.com/merchant/v1' . $url


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Merchant API hash generation had wrong URL. Paytrail API URL is not part of URL used in hash calculation.

## Tests

- [ ] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [x] Visual verification done

## Related Tickets & Documents

Link to any known issues by prefixing the issue number with `#` (e.g. `Related to #1`).

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
